### PR TITLE
fix: Dutch translation file is translated fully and placeholders are fixed

### DIFF
--- a/locales/nl/index.mjs
+++ b/locales/nl/index.mjs
@@ -111,10 +111,10 @@ export default {
         "AM",
         "PM"
       ],
-      "yearAriaLabel": "Year",
-      "monthAriaLabel": "Month",
-      "hourAriaLabel": "Hour",
-      "minuteAriaLabel": "Minute"
+      "yearAriaLabel": "Jaar",
+      "monthAriaLabel": "Maand",
+      "hourAriaLabel": "Uur",
+      "minuteAriaLabel": "Minuut"
     },
     "dateFormats": {
       "datetimeSeconds24": "DD-MM-YYYY HH:mm:ss",
@@ -136,44 +136,44 @@ export default {
     "defaultMessage": "Ongeldig veld",
     "a11y": {
       "file": {
-        "description": "Press Backspace to remove"
+        "description": "Druk op Backspace om te verwijderen"
       },
       "list": {
-        "remove": "Remove item button"
+        "remove": "Verwijder item knop"
       }
     }
   },
   "validation": {
-    "accepted": ":Attribute moet geaccepteerd zijn.",
-    "active_url": ":Attribute is geen geldige URL.",
-    "after": ":Attribute moet een datum na :date zijn.",
-    "after_or_equal": ":Attribute moet een datum na of gelijk aan :date zijn.",
-    "alpha": ":Attribute mag alleen letters bevatten.",
-    "alpha_dash": ":Attribute mag alleen letters, nummers, underscores (_) en streepjes (-) bevatten.",
-    "alpha_num": ":Attribute mag alleen letters en nummers bevatten.",
-    "array": ":Attribute moet geselecteerde elementen bevatten.",
-    "before": ":Attribute moet een datum voor :date zijn.",
-    "before_or_equal": ":Attribute moet een datum voor of gelijk aan :date zijn.",
+    "accepted": ":attribute moet geaccepteerd zijn.",
+    "active_url": ":attribute is geen geldige URL.",
+    "after": ":attribute moet een datum na :date zijn.",
+    "after_or_equal": ":attribute moet een datum na of gelijk aan :date zijn.",
+    "alpha": ":attribute mag alleen letters bevatten.",
+    "alpha_dash": ":attribute mag alleen letters, nummers, underscores (_) en streepjes (-) bevatten.",
+    "alpha_num": ":attribute mag alleen letters en nummers bevatten.",
+    "array": ":attribute moet geselecteerde elementen bevatten.",
+    "before": ":attribute moet een datum voor :date zijn.",
+    "before_or_equal": ":attribute moet een datum voor of gelijk aan :date zijn.",
     "between": {
-      "numeric": ":Attribute moet tussen :min en :max zijn.",
-      "file": ":Attribute moet tussen :min en :max kilobytes zijn.",
-      "string": ":Attribute moet tussen :min en :max karakters zijn.",
-      "array": ":Attribute moet tussen :min en :max items bevatten."
+      "numeric": ":attribute moet tussen :min en :max zijn.",
+      "file": ":attribute moet tussen :min en :max kilobytes zijn.",
+      "string": ":attribute moet tussen :min en :max karakters zijn.",
+      "array": ":attribute moet tussen :min en :max items bevatten."
     },
-    "boolean": ":Attribute moet ja of nee zijn.",
-    "confirmed": ":Attribute bevestiging komt niet overeen.",
-    "date": ":Attribute moet een datum bevatten.",
-    "date_format": ":Attribute moet een geldig datum formaat bevatten.",
-    "date_equals": ":Attribute moet een datum gelijk aan :date zijn.",
-    "different": ":Attribute en :other moeten verschillend zijn.",
-    "digits": ":Attribute moet bestaan uit :digits cijfers.",
-    "digits_between": ":Attribute moet bestaan uit minimaal :min en maximaal :max cijfers.",
-    "dimensions": ":Attribute heeft geen geldige afmetingen voor afbeeldingen.",
-    "distinct": ":Attribute heeft een dubbele waarde.",
-    "email": ":Attribute is geen geldig e-mailadres.",
-    "exists": ":Attribute bestaat niet.",
-    "file": ":Attribute moet een bestand zijn.",
-    "filled": ":Attribute is verplicht.",
+    "boolean": ":attribute moet ja of nee zijn.",
+    "confirmed": ":attribute bevestiging komt niet overeen.",
+    "date": ":attribute moet een datum bevatten.",
+    "date_format": ":attribute moet een geldig datum formaat bevatten.",
+    "date_equals": ":attribute moet een datum gelijk aan :date zijn.",
+    "different": ":attribute en :other moeten verschillend zijn.",
+    "digits": ":attribute moet bestaan uit :digits cijfers.",
+    "digits_between": ":attribute moet bestaan uit minimaal :min en maximaal :max cijfers.",
+    "dimensions": ":attribute heeft geen geldige afmetingen voor afbeeldingen.",
+    "distinct": ":attribute heeft een dubbele waarde.",
+    "email": ":attribute is geen geldig e-mailadres.",
+    "exists": ":attribute bestaat niet.",
+    "file": ":attribute moet een bestand zijn.",
+    "filled": ":attribute is verplicht.",
     "gt": {
       "numeric": "De :attribute moet groter zijn dan :value.",
       "file": "De :attribute moet groter zijn dan :value kilobytes.",
@@ -186,14 +186,14 @@ export default {
       "string": "De :attribute moet minimaal :value tekens bevatten.",
       "array": "De :attribute moet :value waardes of meer bevatten."
     },
-    "image": ":Attribute moet een afbeelding zijn.",
-    "in": ":Attribute is ongeldig.",
-    "in_array": ":Attribute bestaat niet in :other.",
-    "integer": ":Attribute moet een getal zijn.",
-    "ip": ":Attribute moet een geldig IP-adres zijn.",
-    "ipv4": ":Attribute moet een geldig IPv4-adres zijn.",
-    "ipv6": ":Attribute moet een geldig IPv6-adres zijn.",
-    "json": ":Attribute moet een geldige JSON-string zijn.",
+    "image": ":attribute moet een afbeelding zijn.",
+    "in": ":attribute is ongeldig.",
+    "in_array": ":attribute bestaat niet in :other.",
+    "integer": ":attribute moet een getal zijn.",
+    "ip": ":attribute moet een geldig IP-adres zijn.",
+    "ipv4": ":attribute moet een geldig IPv4-adres zijn.",
+    "ipv6": ":attribute moet een geldig IPv6-adres zijn.",
+    "json": ":attribute moet een geldige JSON-string zijn.",
     "lt": {
       "numeric": "De :attribute moet kleiner zijn dan :value.",
       "file": "De :attribute moet kleiner zijn dan :value kilobytes.",
@@ -207,44 +207,44 @@ export default {
       "array": "De :attribute moet :value waardes of minder bevatten."
     },
     "max": {
-      "numeric": ":Attribute mag niet hoger dan :max zijn.",
-      "file": ":Attribute mag niet meer dan :max kilobytes zijn.",
-      "string": ":Attribute mag niet uit meer dan :max tekens bestaan.",
-      "array": ":Attribute mag niet meer dan :max items bevatten."
+      "numeric": ":attribute mag niet hoger dan :max zijn.",
+      "file": ":attribute mag niet meer dan :max kilobytes zijn.",
+      "string": ":attribute mag niet uit meer dan :max tekens bestaan.",
+      "array": ":attribute mag niet meer dan :max items bevatten."
     },
-    "mimes": ":Attribute moet een bestand zijn van het bestandstype :values.",
-    "mimetypes": ":Attribute moet een bestand zijn van het bestandstype :values.",
+    "mimes": ":attribute moet een bestand zijn van het bestandstype :values.",
+    "mimetypes": ":attribute moet een bestand zijn van het bestandstype :values.",
     "min": {
-      "numeric": ":Attribute moet minimaal :min zijn.",
-      "file": ":Attribute moet minimaal :min kilobytes zijn.",
-      "string": ":Attribute moet minimaal :min tekens zijn.",
-      "array": ":Attribute moet minimaal :min items bevatten."
+      "numeric": ":attribute moet minimaal :min zijn.",
+      "file": ":attribute moet minimaal :min kilobytes zijn.",
+      "string": ":attribute moet minimaal :min tekens zijn.",
+      "array": ":attribute moet minimaal :min items bevatten."
     },
     "not_in": "Het formaat van :attribute is ongeldig.",
     "not_regex": "De :attribute formaat is ongeldig.",
-    "numeric": ":Attribute moet een nummer zijn.",
+    "numeric": ":attribute moet een nummer zijn.",
     "present": "The :attribute field must be present.",
-    "regex": ":Attribute formaat is ongeldig.",
-    "required": ":Attribute is verplicht.",
-    "required_if": "The :attribute field is required when :other is :value.",
-    "required_unless": "The :attribute field is required unless :other is in :values.",
-    "required_with": "The :attribute field is required when :values is present.",
-    "required_with_all": "The :attribute field is required when :values are present.",
-    "required_without": "The :attribute field is required when :values is not present.",
-    "required_without_all": "The :attribute field is required when none of :values are present.",
-    "same": ":Attribute en :other moeten overeenkomen.",
+    "regex": ":attribute formaat is ongeldig.",
+    "required": ":attribute is verplicht.",
+    "required_if": "Het :attribute veld is verplicht als :other gelijk is aan :value.",
+    "required_unless": "Het :attribute veld is verplicht tenzij :other is gelijk aan één van :values.",
+    "required_with": "Het :attribute veld is verplicht als :values is geselecteerd.",
+    "required_with_all": "Het :attribute veld is verplicht als :values geselecteerd zijn.",
+    "required_without": "Het :attribute veld is verplicht als :values niet geselecteerd zijn.",
+    "required_without_all": "Het :attribute veld is verplicht geen van :values geselecteerd zijn.",
+    "same": ":attribute en :other moeten overeenkomen.",
     "size": {
-      "numeric": ":Attribute moet :size zijn.",
-      "file": ":Attribute moet :size kilobyte zijn.",
-      "string": ":Attribute moet :size tekens zijn.",
-      "array": ":Attribute moet :size items bevatten."
+      "numeric": ":attribute moet :size zijn.",
+      "file": ":attribute moet :size kilobyte zijn.",
+      "string": ":attribute moet :size tekens zijn.",
+      "array": ":attribute moet :size items bevatten."
     },
-    "string": ":Attribute moet een tekst zijn.",
-    "timezone": ":Attribute moet een geldige tijdzone zijn.",
-    "unique": ":Attribute is al in gebruik.",
+    "string": ":attribute moet een tekst zijn.",
+    "timezone": ":attribute moet een geldige tijdzone zijn.",
+    "unique": ":attribute is al in gebruik.",
     "uploaded": "The :attribute failed to upload.",
-    "url": ":Attribute moet een geldig URL zijn.",
-    "uuid": ":Attribute moet een geldig UUID zijn.",
-    "remote": "The :attribute field is invalid."
+    "url": ":attribute moet een geldig URL zijn.",
+    "uuid": ":attribute moet een geldig UUID zijn.",
+    "remote": "Het :attribute veld is ongeldig."
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

There is no open issue for this PR. I've noticed it when developing using this library and decided to fix it immediately.

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I noticed there were some missing translations in the Dutch translation file, so I've translated those. I also noticed the :attribute placeholder was spelled as :Attribute which gave me the issue that :Attribute was replaced with 'undefined' instead of the actual name of the field in validation messages. This is also fixed

### 📝 Checklist

- [] I have linked an issue or discussion.