### PR TITLE
fix: missing default slots in ListElement

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6203,6 +6203,7 @@ export declare class ListElement implements DefineComponent {
 
   //Slots
   $slots: {
+    'default': (slotProps: { index: number }) => VNode[];
     'label': VNode[];
     'info': VNode[];
     'description': VNode[];


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://vueform.com/community/contribution-guide
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
with typescript, ListElement throws error.
```
<ListElement name="list">
  <template #default="{ index }"> // <!-- #default is not defined
    {{ index }}
    <TextElement :name="index" placeholder="To-do" />
  </template>
</ListElement>
 ```

so, simply add type in `types/index.d.ts`


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.