### PR TITLE
feat: added flag support to regex rule

### DIFF
--- a/src/services/validation/rules/regex.js
+++ b/src/services/validation/rules/regex.js
@@ -2,7 +2,9 @@ import Validator from './../validator'
 
 export default class regex extends Validator {
   check(value) {
-    var regex = new RegExp(this.attributes[0].replace(/^\/|\/[^\/]*$/g, ''))
+    var regex = new RegExp(this.attributes[0].replace(/^\/|\/[^\/]*$/g, ''),            
+                           this.attributes[1] ?? ''
+                          )
 
     return regex.test(value)
   }


### PR DESCRIPTION
second parameter on regex validator is used as regex flags

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://vueform.com/community/contribution-guide
-->

### 🔗 Linked issue
#436 


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added support for regex flags by utilizing second rule parameter

```regex:/^myregex$/,i```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.